### PR TITLE
Allow for user customization of Rmd results report

### DIFF
--- a/R/experiment.R
+++ b/R/experiment.R
@@ -921,21 +921,39 @@ Experiment <- R6::R6Class(
     #'
     #' @param open If \code{TRUE}, open the R Markdown-generated html file in a
     #'   web browser.
+    #' @param author Character string of author names to display in knitted R
+    #'   Markdown document.
     #' @param verbose Level of verboseness (0, 1, 2) when knitting R Markdown.
     #'   Default is 2.
-    #' @param ... Not used.
+    #' @param quiet Default is \code{TRUE}. See [rmarkdown::render()] for 
+    #'   details.
+    #' @param pretty Logical. Specifies whether or not to use pretty R Markdown
+    #'   results template or more barebones R Markdown results template. Default
+    #'   \code{TRUE} uses the pretty template. Set to \code{FALSE} to start from
+    #'   the barebones template, which can be helpful when using your own custom
+    #'   R Markdown theme.
+    #' @param ... Additional arguments to pass to [rmarkdown::render()]. Useful
+    #'   for applying a custom R Markdown output theme.
     #'
     #' @return The original \code{Experiment} object.
-    create_rmd = function(open = TRUE, verbose = 2, ...) {
+    create_rmd = function(open = TRUE, author = "", verbose = 2, quiet = TRUE,
+                          pretty = TRUE, ...) {
       self$create_doc_template()
-      input_fname <- system.file("rmd", "results.Rmd", package = packageName())
+      if (pretty) {
+        input_fname <- system.file("rmd", "results_pretty.Rmd", 
+                                   package = packageName())
+      } else {
+        input_fname <- system.file("rmd", "results.Rmd", 
+                                   package = packageName())
+      }
       output_fname <- file.path(private$.save_dir, paste0(self$name, ".html"))
       params_list <- list(sim_name = self$name, sim_path = private$.save_dir,
-                          verbose = verbose)
+                          author = author, verbose = verbose)
       rmarkdown::render(input = input_fname,
                         params = params_list,
                         output_file = output_fname,
-                        quiet = TRUE)
+                        quiet = quiet,
+                        ...)
       output_fname <- stringr::str_replace_all(output_fname, " ", "\\\\ ")
       if (open) {
         system(paste("open", output_fname))
@@ -1903,14 +1921,26 @@ create_doc_template = function(experiment, experiment_dirname) {
 #'   were previously saved. Used if \code{experiment} argument was not provided.
 #' @param open If \code{TRUE}, open the R Markdown-generated html file in a
 #'   web browser.
+#' @param author Character string of author names to display in knitted R
+#'   Markdown document.
 #' @param verbose Level of verboseness (0, 1, 2) when knitting R Markdown.
 #'   Default is 2.
+#' @param quiet Default is \code{TRUE}. See [rmarkdown::render()] for 
+#'   details.
+#' @param pretty Logical. Specifies whether or not to use pretty R Markdown
+#'   results template or more barebones R Markdown results template. Default
+#'   \code{TRUE} uses the pretty template. Set to \code{FALSE} to start from
+#'   the barebones template, which can be helpful when using your own custom
+#'   R Markdown theme.
+#' @param ... Additional arguments to pass to [rmarkdown::render()]. Useful
+#'   for applying a custom R Markdown output theme.
 #'
 #' @return The original \code{Experiment} object passed to \code{create_rmd}.
 #'
 #' @export
-create_rmd <- function(experiment, experiment_dirname,
-                       open = TRUE, verbose = 2) {
+create_rmd <- function(experiment, experiment_dirname, open = TRUE, 
+                       author = "", verbose = 2, quiet = TRUE, pretty = TRUE,
+                       ...) {
   if (missing(experiment) && missing(experiment_dirname)) {
     stop("Must provide argument for one of experiment or experiment_dirname")
   }
@@ -1928,5 +1958,6 @@ create_rmd <- function(experiment, experiment_dirname,
     }
   }
   experiment$create_doc_template()
-  experiment$create_rmd(open = open, verbose = verbose)
+  experiment$create_rmd(open = open, author = author, verbose = verbose,
+                        quiet = quiet, pretty = pretty, ...)
 }

--- a/inst/rmd/css/general_rmd_theme_addons.css
+++ b/inst/rmd/css/general_rmd_theme_addons.css
@@ -1,0 +1,40 @@
+/* bold navigation bar text */
+.nav a {
+	font-weight: bold;
+	font-size: 13pt;
+}
+
+/* bold text of active tab */
+.pages .nav-tabs>li.active>a {
+	font-weight: bold !important;
+}
+
+/* add box around each step in recipe */
+.padded-panel {
+    padding: 15px;
+    position: relative;
+}
+
+/* create square tab */
+.tabset-square>.nav-pills>li>a,
+.tabset-square>.panel>.nav-pills>li>a {
+    font-size: 14px;
+    font-weight: 500;
+    padding-bottom: 8px;
+    padding-left: 11px;
+    padding-right: 11px;
+    border: 0.5px solid white;
+    border-left: 0px;
+    border-right: 0px;
+}
+
+/* create circl tab */
+.tabset-circle>.nav-pills>li>a,
+.tabset-circle>.panel>.nav-pills>li>a {
+    border-radius: 50%;
+    font-size: 14px;
+    font-weight: normal;
+    padding-bottom: 8px;
+    padding-left: 11px;
+    padding-right: 11px;
+}

--- a/inst/rmd/css/pretty_rmd_theme_addons.css
+++ b/inst/rmd/css/pretty_rmd_theme_addons.css
@@ -104,7 +104,8 @@
     top: -5px;
     right: 15px;
 }
-.tabset-recipe>.panel>.nav-pills>li>a {
+.tabset-recipe>.panel>.nav-pills>li>a,
+.tabset-circle>.panel>.nav-pills>li>a {
     border-radius: 50%;
     font-size: 14px;
     font-weight: normal;
@@ -113,7 +114,8 @@
     padding-right: 11px;
     background-color: #95a5a6;
 }
-.tabset-recipe>.panel>.nav-pills>li.active>a {
+.tabset-recipe>.panel>.nav-pills>li.active>a,
+.tabset-circle>.panel>.nav-pills>li.active>a {
     background-color: #637172;
 }
 

--- a/inst/rmd/results_pretty.Rmd
+++ b/inst/rmd/results_pretty.Rmd
@@ -9,7 +9,7 @@ header-includes:
 output:
   rmdformats::material:
     fig_caption: true
-css: css/general_rmd_theme_addons.css
+css: css/pretty_rmd_theme_addons.css
 params:
   author: 
     label: "Author:"
@@ -24,6 +24,8 @@ params:
     label: "Verbose Level:"
     value: 2
 ---
+
+<script src="js/customNavClass.js"></script>
 
 ```{r setup, include=FALSE}
 options(width = 10000)
@@ -118,7 +120,7 @@ showRecipePart <- function(field_name = c("dgp", "method",
   obj_names <- unique(purrr::reduce(sapply(objs, names), c))
 
   obj_header <- "<p style='font-weight: bold; font-size: 20px'> %s </p>"
-  invis_header <- "\n\n### %s {.tabset .tabset-pills .tabset-fade .tabset-circle}\n\n"
+  invis_header <- "\n\n### %s {.tabset .tabset-pills .tabset-fade .tabset-recipe}\n\n"
   showtype_header <- "\n\n#### %s {.tabset .tabset-pills .tabset-fade .tabset-square}\n\n"
   exp_header <- "\n\n##### %s \n\n"
 
@@ -133,11 +135,11 @@ showRecipePart <- function(field_name = c("dgp", "method",
     cat("<div class='panel panel-default padded-panel'>")
     cat(sprintf(obj_header, obj_name))
 
-    cat(sprintf(showtype_header, fontawesome::fa("readme")))
+    cat(sprintf(showtype_header, fontawesome::fa("readme", fill = "white")))
     pasteMd(file.path(doc_dir, paste0(field_name, "s"),
                       paste0(obj_name, ".md")))
 
-    cat(sprintf(showtype_header, fontawesome::fa("code")))
+    cat(sprintf(showtype_header, fontawesome::fa("code", fill = "white")))
     keep_objs <- purrr::map(objs, obj_name)
     keep_objs[sapply(keep_objs, is.null)] <- NULL
     if (all(purrr::map_lgl(keep_objs,
@@ -248,7 +250,7 @@ showResults <- function(dir_name, depth, base = FALSE, show_header = TRUE,
   visualize_results <- getResults(visualize_fname)
 
   if (!is.null(eval_results)) {
-    cat(sprintf(showtype_template, fontawesome::fa("table")))
+    cat(sprintf(showtype_template, fontawesome::fa("table", fill = "white")))
     for (eval_name in names(eval_results)) {
       if (verbose >= 2) {
         message(rep(" ", depth + 1), eval_name)
@@ -266,7 +268,7 @@ showResults <- function(dir_name, depth, base = FALSE, show_header = TRUE,
 
   if (!is.null(visualize_results)) {
     cat(sprintf(showtype_template,
-                fontawesome::fa("chart-bar")))
+                fontawesome::fa("chart-bar", fill = "white")))
     for (plot_name in names(visualize_results)) {
       if (verbose >= 2) {
         message(rep(" ", depth + 1), plot_name)
@@ -287,10 +289,16 @@ showResults <- function(dir_name, depth, base = FALSE, show_header = TRUE,
             cat(sprintf(plt_template, plt_name))
           }
           plt <- plts[[plt_name]]
+          if (inherits(plt, "plotly")) {
+            add_class <- c("panel panel-default padded-panel")
+          } else {
+            add_class <- NULL
+          }
           subchunkify(plt, i = chunk_idx,
                       fig_height = visualizer$rmd_options$height,
                       fig_width = visualizer$rmd_options$width,
-                      other_args = "out.width = '100%'")
+                      other_args = "out.width = '100%'",
+                      add_class = add_class)
           chunk_idx <<- chunk_idx + 1
         }
       }
@@ -300,7 +308,7 @@ showResults <- function(dir_name, depth, base = FALSE, show_header = TRUE,
   if (!is.null(exp)) {
     if ((length(exp$get_vary_across()$dgp) != 0) |
         (length(exp$get_vary_across()$method) != 0)) {
-      cat(sprintf(showtype_template, fontawesome::fa("code")))
+      cat(sprintf(showtype_template, fontawesome::fa("code", fill = "white")))
       cat("<b>Parameter Values</b>")
       subchunkify(exp$get_vary_across(),
                   chunk_idx, other_args = "max.height='200px'")

--- a/man/Experiment.Rd
+++ b/man/Experiment.Rd
@@ -403,7 +403,14 @@ Knits an R Markdown file summarizing the results of an
 \code{Experiment}. Outputs an R Markdown-generated html file, saved in
 the \code{Experiment}'s root results directory.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Experiment$create_rmd(open = TRUE, verbose = 2, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Experiment$create_rmd(
+  open = TRUE,
+  author = "",
+  verbose = 2,
+  quiet = TRUE,
+  pretty = TRUE,
+  ...
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -412,10 +419,23 @@ the \code{Experiment}'s root results directory.
 \item{\code{open}}{If \code{TRUE}, open the R Markdown-generated html file in a
 web browser.}
 
+\item{\code{author}}{Character string of author names to display in knitted R
+Markdown document.}
+
 \item{\code{verbose}}{Level of verboseness (0, 1, 2) when knitting R Markdown.
 Default is 2.}
 
-\item{\code{...}}{Not used.}
+\item{\code{quiet}}{Default is \code{TRUE}. See \code{\link[rmarkdown:render]{rmarkdown::render()}} for
+details.}
+
+\item{\code{pretty}}{Logical. Specifies whether or not to use pretty R Markdown
+results template or more barebones R Markdown results template. Default
+\code{TRUE} uses the pretty template. Set to \code{FALSE} to start from
+the barebones template, which can be helpful when using your own custom
+R Markdown theme.}
+
+\item{\code{...}}{Additional arguments to pass to \code{\link[rmarkdown:render]{rmarkdown::render()}}. Useful
+for applying a custom R Markdown output theme.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/create_rmd.Rd
+++ b/man/create_rmd.Rd
@@ -4,7 +4,16 @@
 \alias{create_rmd}
 \title{Create an R Markdown file summarizing the results of an \code{Experiment}.}
 \usage{
-create_rmd(experiment, experiment_dirname, open = TRUE, verbose = 2)
+create_rmd(
+  experiment,
+  experiment_dirname,
+  open = TRUE,
+  author = "",
+  verbose = 2,
+  quiet = TRUE,
+  pretty = TRUE,
+  ...
+)
 }
 \arguments{
 \item{experiment}{An \code{Experiment} object.}
@@ -15,8 +24,23 @@ were previously saved. Used if \code{experiment} argument was not provided.}
 \item{open}{If \code{TRUE}, open the R Markdown-generated html file in a
 web browser.}
 
+\item{author}{Character string of author names to display in knitted R
+Markdown document.}
+
 \item{verbose}{Level of verboseness (0, 1, 2) when knitting R Markdown.
 Default is 2.}
+
+\item{quiet}{Default is \code{TRUE}. See \code{\link[rmarkdown:render]{rmarkdown::render()}} for
+details.}
+
+\item{pretty}{Logical. Specifies whether or not to use pretty R Markdown
+results template or more barebones R Markdown results template. Default
+\code{TRUE} uses the pretty template. Set to \code{FALSE} to start from
+the barebones template, which can be helpful when using your own custom
+R Markdown theme.}
+
+\item{...}{Additional arguments to pass to \code{\link[rmarkdown:render]{rmarkdown::render()}}. Useful
+for applying a custom R Markdown output theme.}
 }
 \value{
 The original \code{Experiment} object passed to \code{create_rmd}.

--- a/tests/testthat/test-create-rmd-doc.R
+++ b/tests/testthat/test-create-rmd-doc.R
@@ -63,6 +63,19 @@ test_that("Automated R Markdown documentation works properly", {
   results <- greatgrandchild2$run(save = TRUE, verbose = 0)
 
   expect_error(base_experiment$create_rmd(open = FALSE, verbose = 0), NA)
+  expect_error(
+    base_experiment$create_rmd(
+      open = FALSE, verbose = 0, pretty = FALSE,
+      output_format = rmarkdown::html_document()),
+    NA
+  )
+  expect_error(
+    base_experiment$create_rmd(
+      open = FALSE, verbose = 0, pretty = FALSE, 
+      output_options = list(css = "css/pretty_rmd_theme_addons.css")
+    ),
+    NA
+  )
 })
 
 test_that("Visualizations in R Markdown documentation render correctly", {


### PR DESCRIPTION
Customization is enabled through arguments passed to `rmarkdown::render(...)`.

Closes #35 