### PR TITLE
Add checkpointing and expand cache reuse for Experiment$fit()

### DIFF
--- a/R/experiment_helpers.R
+++ b/R/experiment_helpers.R
@@ -2,6 +2,9 @@
 #'
 #' @name shared_experiment_helpers_args
 #'
+#' @param checkpoint_n_reps The number of experiment replicates to compute
+#'   before saving results to disk. If 0 (the default), no checkpoints are
+#'   saved.
 #' @param dgp A \code{DGP} object.
 #' @param evaluator An \code{Evaluator} object.
 #' @param eval_results A list of result tibbles, as returned by the
@@ -27,7 +30,7 @@
 #' @param use_cached Logical. If \code{TRUE}, find and return previously saved
 #'   results. If cached results cannot be found, continue as if
 #'   \code{use_cached} was \code{FALSE}.
-#' @param vary_params A vector of parameter names that are varied across in the 
+#' @param vary_params A vector of parameter names that are varied across in the
 #'   \code{Experiment}.
 #' @param verbose Level of verbosity. Default is 1, which prints out messages
 #'   after major checkpoints in the experiment. If 2, prints additional
@@ -102,13 +105,15 @@ create_experiment <- function(name = "experiment",
 run_experiment <- function(experiment, n_reps = 1,
                            parallel_strategy = c("reps"), future.globals = NULL,
                            future.packages = NULL, future.seed = TRUE,
-                           use_cached = FALSE, save = FALSE, verbose = 1, ...) {
+                           use_cached = FALSE, save = FALSE,
+                           checkpoint_n_reps = 0, verbose = 1, ...) {
   return(experiment$run(n_reps = n_reps,
                         parallel_strategy = parallel_strategy,
                         future.globals = future.globals,
                         future.packages = future.packages,
                         future.seed = future.seed, use_cached = use_cached,
-                        save = save, verbose = verbose, ...))
+                        save = save, checkpoint_n_reps = checkpoint_n_reps,
+                        verbose = verbose, ...))
 }
 
 #' Generate data from each \code{DGP} in the \code{Experiment}.
@@ -150,13 +155,14 @@ generate_data <- function(experiment, n_reps=1, ...) {
 fit_experiment <- function(experiment, n_reps=1, parallel_strategy = c("reps"),
                            future.globals = NULL, future.packages = NULL,
                            future.seed = TRUE, use_cached = FALSE, save = FALSE,
-                           verbose = 1, ...) {
+                           checkpoint_n_reps = 0, verbose = 1, ...) {
   return(experiment$fit(n_reps = n_reps,
                         parallel_strategy = parallel_strategy,
                         future.globals = future.globals,
                         future.packages = future.packages,
                         future.seed = future.seed, use_cached = use_cached,
-                        save = save, verbose = verbose, ...))
+                        save = save, checkpoint_n_reps = checkpoint_n_reps,
+                        verbose = verbose, ...))
 }
 
 #' Evaluate an \code{Experiment}.

--- a/man/fit_experiment.Rd
+++ b/man/fit_experiment.Rd
@@ -13,6 +13,7 @@ fit_experiment(
   future.seed = TRUE,
   use_cached = FALSE,
   save = FALSE,
+  checkpoint_n_reps = 0,
   verbose = 1,
   ...
 )
@@ -44,6 +45,10 @@ results. If cached results cannot be found, continue as if
 \code{use_cached} was \code{FALSE}.}
 
 \item{save}{If \code{TRUE}, save outputs to disk.}
+
+\item{checkpoint_n_reps}{The number of experiment replicates to compute
+before saving results to disk. If 0 (the default), no checkpoints are
+saved.}
 
 \item{verbose}{Level of verbosity. Default is 1, which prints out messages
 after major checkpoints in the experiment. If 2, prints additional

--- a/man/run_experiment.Rd
+++ b/man/run_experiment.Rd
@@ -13,6 +13,7 @@ run_experiment(
   future.seed = TRUE,
   use_cached = FALSE,
   save = FALSE,
+  checkpoint_n_reps = 0,
   verbose = 1,
   ...
 )
@@ -44,6 +45,10 @@ results. If cached results cannot be found, continue as if
 \code{use_cached} was \code{FALSE}.}
 
 \item{save}{If \code{TRUE}, save outputs to disk.}
+
+\item{checkpoint_n_reps}{The number of experiment replicates to compute
+before saving results to disk. If 0 (the default), no checkpoints are
+saved.}
 
 \item{verbose}{Level of verbosity. Default is 1, which prints out messages
 after major checkpoints in the experiment. If 2, prints additional

--- a/man/shared_experiment_helpers_args.Rd
+++ b/man/shared_experiment_helpers_args.Rd
@@ -4,6 +4,10 @@
 \alias{shared_experiment_helpers_args}
 \title{Arguments that are shared by multiple Experiment helper funs.}
 \arguments{
+\item{checkpoint_n_reps}{The number of experiment replicates to compute
+before saving results to disk. If 0 (the default), no checkpoints are
+saved.}
+
 \item{dgp}{A \code{DGP} object.}
 
 \item{evaluator}{An \code{Evaluator} object.}

--- a/tests/testthat/_snaps/experiment.md
+++ b/tests/testthat/_snaps/experiment.md
@@ -623,21 +623,9 @@
 # Capturing errors, warnings, and messages from user-defined functions works as expected
 
     Code
-      experiment$fit(n_reps = 2)
+      invisible(experiment$fit(n_reps = 2))
     Message <simpleMessage>
       Fitting error-tracking...
-    Message <packageStartupMessage>
-      
-      Attaching package: 'dplyr'
-      The following object is masked from 'package:testthat':
-      
-          matches
-      The following objects are masked from 'package:stats':
-      
-          filter, lag
-      The following objects are masked from 'package:base':
-      
-          intersect, setdiff, setequal, union
     Warning <simpleWarning>
       rho must be greater than 0.5
     Message <simpleMessage>
@@ -686,29 +674,13 @@
       3 isn't in vec
       3 isn't in vec
       3 isn't in vec
-      Fitting completed | time taken: _x_ minutes
+      2 reps completed (totals: 2/2) | time taken: _x_ minutes
       ==============================
-    Output
-      # A tibble: 48 x 14
-         .rep  .dgp_name .method_name param2 vec       rho_dgp noise_level_dgp rho_method
-         <chr> <chr>     <chr>         <dbl> <list>    <lgl>   <lgl>           <lgl>     
-       1 1     dgp1      method_test       2 <dbl [3]> NA      NA              NA        
-       2 1     dgp1      method_test       4 <dbl [3]> NA      NA              NA        
-       3 1     dgp1      method_test       2 <int [4]> NA      NA              NA        
-       4 1     dgp1      method_test       4 <int [4]> NA      NA              NA        
-       5 1     dgp1      method_test       2 <dbl [3]> NA      NA              NA        
-       6 1     dgp1      method_test       4 <dbl [3]> NA      NA              NA        
-       7 1     dgp1      method_test       2 <int [4]> NA      NA              NA        
-       8 1     dgp1      method_test       4 <int [4]> NA      NA              NA        
-       9 1     dgp_test  method_test       2 <dbl [3]> NA      NA              NA        
-      10 1     dgp_test  method_test       4 <dbl [3]> NA      NA              NA        
-      # ... with 38 more rows, and 6 more variables: noise_level_method <lgl>,
-      #   rho <dbl>, noise_level <dbl>, .n <dbl>, .rho <dbl>, .noise_level <dbl>
 
 ---
 
     Code
-      fit_results <- experiment$fit(n_reps = 2, verbose = 2)
+      invisible(fit_results <- experiment$fit(n_reps = 2, verbose = 2))
     Message <simpleMessage>
       Fitting error-tracking...
     Output
@@ -1064,13 +1036,13 @@
       3 isn't in vec
       3 isn't in vec
       3 isn't in vec
-      Fitting completed | time taken: _x_ minutes
+      2 reps completed (totals: 2/2) | time taken: _x_ minutes
       ==============================
 
 ---
 
     Code
-      experiment$evaluate(fit_results)
+      invisible(experiment$evaluate(fit_results))
     Message <simpleMessage>
       Evaluating error-tracking...
     Warning <simpleWarning>
@@ -1078,20 +1050,11 @@
     Message <simpleMessage>
       Evaluation completed | time taken: _x_ minutes
       ==============================
-    Output
-      $evaluator1
-      # A tibble: 1 x 14
-        .rep  .dgp_name .method_name param2 vec       rho_dgp noise_level_dgp rho_method
-        <chr> <chr>     <chr>         <dbl> <list>    <lgl>   <lgl>           <lgl>     
-      1 1     dgp1      method_test       2 <dbl [3]> NA      NA              NA        
-      # ... with 6 more variables: noise_level_method <lgl>, rho <dbl>,
-      #   noise_level <dbl>, .n <dbl>, .rho <dbl>, .noise_level <dbl>
-      
 
 ---
 
     Code
-      eval_results <- experiment$evaluate(fit_results, verbose = 2)
+      invisible(eval_results <- experiment$evaluate(fit_results, verbose = 2))
     Message <simpleMessage>
       Evaluating error-tracking...
     Output
@@ -1123,7 +1086,7 @@
 ---
 
     Code
-      experiment$visualize(fit_results, eval_results)
+      invisible(experiment$visualize(fit_results, eval_results))
     Message <simpleMessage>
       Visualizing error-tracking...
     Warning <simpleWarning>
@@ -1131,15 +1094,12 @@
     Message <simpleMessage>
       Visualization completed | time taken: _x_ minutes
       ==============================
-    Output
-      $visualizer1
-      [1] "plot"
-      
 
 ---
 
     Code
-      experiment$visualize(fit_results, eval_results, verbose = 2)
+      invisible(viz_results <- experiment$visualize(fit_results, eval_results,
+        verbose = 2))
     Message <simpleMessage>
       Visualizing error-tracking...
     Output
@@ -1169,15 +1129,11 @@
     Message <simpleMessage>
       Visualization completed | time taken: _x_ minutes
       ==============================
-    Output
-      $visualizer1
-      [1] "plot"
-      
 
 ---
 
     Code
-      experiment$visualize(fit_results, eval_results, verbose = 2)
+      invisible(experiment$visualize(fit_results, eval_results, verbose = 2))
     Message <simpleMessage>
       Visualizing error-tracking...
     Output


### PR DESCRIPTION
* New argument checkpoint_n_reps to Experiment$fit() and Experiment$run() lets
the user determine how many experiment replicates to compute prior to saving
results to disk to guard against unexpected errors external to the
experiment (e.g., system crashes).

* When use_cached is TRUE and there are existing cached replicates but less than
the n_reps argument, the experiment will now reuse the cache and only compute
the remaining replicates.

Closes #11, closes #90.