### PR TITLE
Parallel error catching

### DIFF
--- a/R/experiment.R
+++ b/R/experiment.R
@@ -1458,6 +1458,14 @@ Experiment <- R6::R6Class(
       invisible(self)
     },
     remove_dgp = function(name = NULL, ...) {
+      if (is.null(name)) {
+        private$.vary_across_list[["dgp"]] <- list()
+      } else {
+        vary_across_sublist <- private$.vary_across_list[["dgp"]][[name]]
+        if (!is.null(vary_across_sublist)) {
+          self$remove_vary_across(dgp = name)
+        }
+      }
       private$.remove_obj("dgp", name)
       invisible(self)
     },
@@ -1475,6 +1483,14 @@ Experiment <- R6::R6Class(
       invisible(self)
     },
     remove_method = function(name = NULL, ...) {
+      if (is.null(name)) {
+        private$.vary_across_list[["method"]] <- list()
+      } else {
+        vary_across_sublist <- private$.vary_across_list[["method"]][[name]]
+        if (!is.null(vary_across_sublist)) {
+          self$remove_vary_across(method = name)
+        }
+      }
       private$.remove_obj("method", name)
       invisible(self)
     },

--- a/tests/testthat/_snaps/experiment.md
+++ b/tests/testthat/_snaps/experiment.md
@@ -683,14 +683,15 @@
       invisible(fit_results <- experiment$fit(n_reps = 2, verbose = 2))
     Message <simpleMessage>
       Fitting error-tracking...
-    Output
-      
-      Warning occured while processing *dgp1* with params:
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp1" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 1
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -698,10 +699,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -709,15 +710,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp1* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp1" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 2
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -725,10 +728,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -736,15 +739,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp_test" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 1
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -752,10 +757,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -763,10 +768,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -774,10 +779,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -785,15 +790,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp_test" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 2
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -801,10 +808,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -812,10 +819,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -823,10 +830,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -834,15 +841,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp1* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp1" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 1
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -850,10 +859,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -861,15 +870,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp1* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp1" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 2
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -877,10 +888,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -888,15 +899,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp_test" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 1
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -904,10 +917,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -915,10 +928,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -926,10 +939,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -937,15 +950,17 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 1
-      The message: 3 isn't in vec
-      
-      
-      Warning occured while processing *dgp_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Warning <simChefWarning>
+      rho must be greater than 0.5
+      The above warning occurred while processing "dgp_test" with the following params:
        $ rho        : num 0.2
        $ noise_level: num 2
-      The warning: rho must be greater than 0.5
-      
-      Message occured while processing *method_test* with params:
+    Warning <simpleWarning>
+      rho must be greater than 0.5
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -953,10 +968,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -964,10 +979,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.2
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 2
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -975,10 +990,10 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-      
-      Message occured while processing *method_test* with params:
+    Message <simpleMessage>
+      3 isn't in vec
+    Message <simChefMessage>
+      The message below occurred while processing "method_test" with the following params:
        $ param2   : num 4
        $ vec      : int [1:4] 4 5 6 7
        $ data_list:List of 1
@@ -986,55 +1001,7 @@
         .. ..$ .n          : num 10
         .. ..$ .rho        : num 0.9
         .. ..$ .noise_level: num 2
-      The message: 3 isn't in vec
-      
-    Warning <simpleWarning>
-      rho must be greater than 0.5
     Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
-    Warning <simpleWarning>
-      rho must be greater than 0.5
-    Message <simpleMessage>
-      3 isn't in vec
-      3 isn't in vec
-      3 isn't in vec
       3 isn't in vec
       2 reps completed (totals: 2/2) | time taken: _x_ minutes
       ==============================
@@ -1057,9 +1024,9 @@
       invisible(eval_results <- experiment$evaluate(fit_results, verbose = 2))
     Message <simpleMessage>
       Evaluating error-tracking...
-    Output
-      
-      Warning occured while processing *evaluator1* with params:
+    Warning <simChefWarning>
+      that's a lot of rows
+      The above warning occurred while processing "evaluator1" with the following params:
        $ fit_results: tibble [48 x 10] (S3: tbl_df/tbl/data.frame)
         ..$ .rep        : chr [1:48] "1" "1" "1" "1" ...
         ..$ .dgp_name   : chr [1:48] "dgp1" "dgp1" "dgp1" "dgp1" ...
@@ -1072,7 +1039,6 @@
         ..$ .rho        : num [1:48] 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 ...
         ..$ .noise_level: num [1:48] 1 1 1 1 2 2 2 2 1 1 ...
        $ vary_params: chr [1:6] "rho" "noise_level" "rho" "noise_level" ...
-      The warning: that's a lot of rows
     Warning <simpleWarning>
       that's a lot of rows
     Message <simpleMessage>
@@ -1098,9 +1064,9 @@
         verbose = 2))
     Message <simpleMessage>
       Visualizing error-tracking...
-    Output
-      
-      Warning occured while processing *visualizer1* with params:
+    Warning <simChefWarning>
+      False alarm!
+      The above warning occurred while processing "visualizer1" with the following params:
        $ fit_results : tibble [48 x 10] (S3: tbl_df/tbl/data.frame)
         ..$ .rep        : chr [1:48] "1" "1" "1" "1" ...
         ..$ .dgp_name   : chr [1:48] "dgp1" "dgp1" "dgp1" "dgp1" ...
@@ -1115,7 +1081,6 @@
        $ eval_results:List of 1
         ..$ evaluator1: tibble [1 x 10] (S3: tbl_df/tbl/data.frame)
        $ vary_params : chr [1:6] "rho" "noise_level" "rho" "noise_level" ...
-      The warning: False alarm!
     Warning <simpleWarning>
       False alarm!
     Message <simpleMessage>
@@ -1128,9 +1093,9 @@
       invisible(experiment$visualize(fit_results, eval_results, verbose = 2))
     Message <simpleMessage>
       Visualizing error-tracking...
-    Output
-      
-      Warning occured while processing *visualizer1* with params:
+    Warning <simChefWarning>
+      False alarm!
+      The above warning occurred while processing "visualizer1" with the following params:
        $ fit_results : tibble [48 x 10] (S3: tbl_df/tbl/data.frame)
         ..$ .rep        : chr [1:48] "1" "1" "1" "1" ...
         ..$ .dgp_name   : chr [1:48] "dgp1" "dgp1" "dgp1" "dgp1" ...
@@ -1145,12 +1110,11 @@
        $ eval_results:List of 1
         ..$ evaluator1: tibble [1 x 10] (S3: tbl_df/tbl/data.frame)
        $ vary_params : chr [1:6] "rho" "noise_level" "rho" "noise_level" ...
-      The warning: False alarm!
     Warning <simpleWarning>
       False alarm!
-    Output
-      
-      Error occured while processing *visualizer2* with params:
+    Error <simChefError>
+      Oh no!
+      The above error occurred while processing "visualizer2" with the following params:
        $ fit_results : tibble [48 x 10] (S3: tbl_df/tbl/data.frame)
         ..$ .rep        : chr [1:48] "1" "1" "1" "1" ...
         ..$ .dgp_name   : chr [1:48] "dgp1" "dgp1" "dgp1" "dgp1" ...
@@ -1165,7 +1129,4 @@
        $ eval_results:List of 1
         ..$ evaluator1: tibble [1 x 10] (S3: tbl_df/tbl/data.frame)
        $ vary_params : chr [1:6] "rho" "noise_level" "rho" "noise_level" ...
-      The error: Oh no!
-    Error <simpleError>
-      Oh no!
 


### PR DESCRIPTION
Catch and return errors from all parallel workers in `Experiment$fit`. Also return partial results from DGP+Method combos that were successful before the worker encountered the first error. The error object signaled by `Experiment$fit` contains a `tibble` of the partial results and errors, and each error in the `tibble` contains the input data and the name of the DGP/Method that was being processed when the error occurred.

Close #103 