### PR TITLE
Preview `Evaluator` results in R Markdown report

### DIFF
--- a/R/evaluator.R
+++ b/R/evaluator.R
@@ -203,6 +203,13 @@ Evaluator <- R6::R6Class(
     #'   `Evaluator`'s results as a table in the R Markdown report.
     doc_show = TRUE,
 
+    #' @field doc_nrows Maximum number of rows to show in the `Evaluator`'s
+    #'   results table in the R Markdown report. If the number of rows in the
+    #'   table exceeds this value, the table will be truncated and a message
+    #'   will be displayed indicating the number of rows that were omitted.
+    #'   Default is `NULL`, which shows all rows.
+    doc_nrows = NULL,
+
     # NOTE: R6 methods can't use the `@inheritParams` tag. If you want to update
     # the `@param` tags below, do so in the `create_evaluator()` docs above and
     # then copy-paste the corresponding `@param` tags below.
@@ -220,17 +227,23 @@ Evaluator <- R6::R6Class(
     #'   for this argument.
     #' @param .doc_show If `TRUE` (default), show `Evaluator`'s results as a table
     #'   in the R Markdown report; if `FALSE`, hide output in the R Markdown report.
+    #' @param .doc_nrows Maximum number of rows to show in the `Evaluator`'s results
+    #'   table in the R Markdown report. If the number of rows in the table exceeds
+    #'   this value, the table will be truncated and a message will be displayed
+    #'   indicating the number of rows that were omitted. Default is `NULL`, which
+    #'   shows all rows.
     #' @param ... User-defined arguments to pass into `.eval_fun()`.
     #'
     #' @return A new instance of `Evaluator`.
     initialize = function(.eval_fun, .name = NULL, .doc_options = list(),
-                          .doc_show = TRUE, ...) {
+                          .doc_show = TRUE, .doc_nrows = NULL, ...) {
       self$eval_fun <- .eval_fun
       self$name <- .name
       for (opt in names(.doc_options)) {
         self$doc_options[[opt]] <- .doc_options[[opt]]
       }
       self$doc_show <- .doc_show
+      self$doc_nrows <- .doc_nrows
       self$eval_params <- rlang::list2(...)
     },
 

--- a/R/experiment-helpers.R
+++ b/R/experiment-helpers.R
@@ -1051,8 +1051,12 @@ get_cached_results <- function(experiment, results_type, verbose = 0) {
 #' @param name Name of `Evaluator` or `Visualizer` to set R Markdown
 #'   options.
 #' @param show If `TRUE`, show output; if `FALSE`, hide output in
-#'   R Markdown report. Default `NULL` does not change the "show" field
+#'   R Markdown report. Default `NULL` does not change the "doc_show" field
 #'   in `Evaluator`/`Visualizer`.
+#' @param nrows Maximum number of rows to show in the `Evaluator`'s results
+#'   table in the R Markdown report. If `NULL`, shows all rows. Default does
+#'   not change the "doc_nrows" field in the `Evaluator`. Argument is
+#'   ignored if `field_name = "visualizer"`.
 #' @param ... Named R Markdown options to set. If `field_name = "visualizer"`,
 #'   options are "height" and "width". If `field_name = "evaluator"`,
 #'   see options for [vthemes::pretty_DT()].
@@ -1126,10 +1130,10 @@ get_cached_results <- function(experiment, results_type, verbose = 0) {
 #'
 #' @export
 set_doc_options <- function(experiment, field_name = c("evaluator", "visualizer"),
-                            name, show = NULL, ...) {
+                            name, show = NULL, nrows, ...) {
   field_name <- match.arg(field_name)
   experiment$set_doc_options(field_name = field_name, name = name, show = show,
-                             ...)
+                             nrows = nrows, ...)
 }
 
 #' Set R Markdown options for `Evaluator` and `Visualizer` outputs in

--- a/R/experiment.R
+++ b/R/experiment.R
@@ -1911,14 +1911,19 @@ Experiment <- R6::R6Class(
     #' @param name Name of `Evaluator` or `Visualizer` to set R Markdown
     #'   options.
     #' @param show If `TRUE`, show output; if `FALSE`, hide output in
-    #'   R Markdown report. Default `NULL` does not change the "show" field
+    #'   R Markdown report. Default `NULL` does not change the "doc_show" field
     #'   in `Evaluator`/`Visualizer`.
+    #' @param nrows Maximum number of rows to show in the `Evaluator`'s results
+    #'   table in the R Markdown report. If `NULL`, shows all rows. Default does
+    #'   not change the "doc_nrows" field in the `Evaluator`. Argument is
+    #'   ignored if `field_name = "visualizer"`.
     #' @param ... Named R Markdown options to set. If `field_name = "visualizer"`,
     #'   options are "height" and "width". If `field_name = "evaluator"`,
     #'   see options for [vthemes::pretty_DT()].
     #'
     #' @return The `Experiment` object, invisibly.
-    set_doc_options = function(field_name, name, show = NULL, ...) {
+    set_doc_options = function(field_name, name, show = NULL, nrows, ...) {
+      field_name <- match.arg(field_name, c("evaluator", "visualizer"))
       obj_list <- private$.get_obj_list(field_name)
       if (!name %in% names(obj_list)) {
         abort(
@@ -1932,6 +1937,11 @@ Experiment <- R6::R6Class(
       list_name <- paste0(".", field_name, "_list")
       if (!is.null(show)) {
         private[[list_name]][[name]]$doc_show <- show
+      }
+      if (field_name == "evaluator") {
+        if (!missing(nrows)) {
+          private[[list_name]][[name]]$doc_nrows <- nrows
+        }
       }
       doc_options <- list(...)
       if (length(doc_options) > 0) {

--- a/inst/rmd/results.Rmd
+++ b/inst/rmd/results.Rmd
@@ -453,6 +453,22 @@ show_results <- function(dir_name, depth, base = FALSE, show_header = TRUE,
           sprintf(figname_template, eval_name),
           old_text = results, write_flag = write_flag
         )
+        if (is.null(evaluator$doc_nrows)) {
+          eval_results_show <- eval_results[[eval_name]]
+        } else {
+          keep_rows <- 1:min(evaluator$doc_nrows, nrow(eval_results[[eval_name]]))
+          eval_results_show <- eval_results[[eval_name]][keep_rows, ]
+          if (nrow(eval_results[[eval_name]]) > evaluator$doc_nrows) {
+            omitted_nrows <- nrow(eval_results[[eval_name]]) - evaluator$doc_nrows
+            results <- write(
+              sprintf(
+                "Showing preview of %s results. %s rows have been omitted.\n\n",
+                eval_name, omitted_nrows
+              ),
+              old_text = results, write_flag = write_flag
+            )
+          }
+        }
         if (write_flag) {
           results <- sprintf(
             "show_results('%s', '%s', 'evaluator')", dir_name, eval_name
@@ -462,7 +478,7 @@ show_results <- function(dir_name, depth, base = FALSE, show_header = TRUE,
         } else {
           do.call(
             vthemes::pretty_DT,
-            c(list(eval_results[[eval_name]]), evaluator$doc_options)
+            c(list(eval_results_show), evaluator$doc_options)
           ) %>%
             vthemes::subchunkify(i = chunk_idx)
           chunk_idx <<- chunk_idx + 1

--- a/inst/rmd/results_header_template.Rmd
+++ b/inst/rmd/results_header_template.Rmd
@@ -126,8 +126,15 @@ show_results <- function(dir_name, name,
   viz_results <- get_results(viz_fname)
   
   if (field_name == "evaluator") {
+    doc_nrows <- exp$get_evaluators()[[name]]$doc_nrows
+    if (is.null(doc_nrows)) {
+      eval_results_show <- eval_results[[name]]
+    } else {
+      keep_rows <- 1:min(doc_nrows, nrow(eval_results[[name]]))
+      eval_results_show <- eval_results[[name]][keep_rows, ]
+    }
     do.call(vthemes::pretty_DT,
-            c(list(eval_results[[name]]),
+            c(list(eval_results_show),
               exp$get_evaluators()[[name]]$doc_options))
   } else if (field_name == "visualizer") {
     viz_results[[name]]

--- a/man/Evaluator.Rd
+++ b/man/Evaluator.Rd
@@ -109,6 +109,12 @@ the displayed \code{Evaluator}'s results table in the knitted R Markdown report.
 
 \item{\code{doc_show}}{Boolean indicating whether or not to show the
 \code{Evaluator}'s results as a table in the R Markdown report.}
+
+\item{\code{doc_nrows}}{Maximum number of rows to show in the \code{Evaluator}'s
+results table in the R Markdown report. If the number of rows in the
+table exceeds this value, the table will be truncated and a message
+will be displayed indicating the number of rows that were omitted.
+Default is \code{NULL}, which shows all rows.}
 }
 \if{html}{\out{</div>}}
 }
@@ -132,6 +138,7 @@ Initialize a new \code{Evaluator} object.
   .name = NULL,
   .doc_options = list(),
   .doc_show = TRUE,
+  .doc_nrows = NULL,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -153,6 +160,12 @@ for this argument.}
 
 \item{\code{.doc_show}}{If \code{TRUE} (default), show \code{Evaluator}'s results as a table
 in the R Markdown report; if \code{FALSE}, hide output in the R Markdown report.}
+
+\item{\code{.doc_nrows}}{Maximum number of rows to show in the \code{Evaluator}'s results
+table in the R Markdown report. If the number of rows in the table exceeds
+this value, the table will be truncated and a message will be displayed
+indicating the number of rows that were omitted. Default is \code{NULL}, which
+shows all rows.}
 
 \item{\code{...}}{User-defined arguments to pass into \code{.eval_fun()}.}
 }

--- a/man/Experiment.Rd
+++ b/man/Experiment.Rd
@@ -940,7 +940,7 @@ Set R Markdown options for \code{Evaluator} or \code{Visualizer}
 outputs in the summary report. Some options include the height/width of
 plots and number of digits to show in tables.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Experiment$set_doc_options(field_name, name, show = NULL, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Experiment$set_doc_options(field_name, name, show = NULL, nrows, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -952,8 +952,13 @@ plots and number of digits to show in tables.
 options.}
 
 \item{\code{show}}{If \code{TRUE}, show output; if \code{FALSE}, hide output in
-R Markdown report. Default \code{NULL} does not change the "show" field
+R Markdown report. Default \code{NULL} does not change the "doc_show" field
 in \code{Evaluator}/\code{Visualizer}.}
+
+\item{\code{nrows}}{Maximum number of rows to show in the \code{Evaluator}'s results
+table in the R Markdown report. If \code{NULL}, shows all rows. Default does
+not change the "doc_nrows" field in the \code{Evaluator}. Argument is
+ignored if \code{field_name = "visualizer"}.}
 
 \item{\code{...}}{Named R Markdown options to set. If \code{field_name = "visualizer"},
 options are "height" and "width". If \code{field_name = "evaluator"},

--- a/man/set_doc_options.Rd
+++ b/man/set_doc_options.Rd
@@ -10,6 +10,7 @@ set_doc_options(
   field_name = c("evaluator", "visualizer"),
   name,
   show = NULL,
+  nrows,
   ...
 )
 }
@@ -22,8 +23,13 @@ set_doc_options(
 options.}
 
 \item{show}{If \code{TRUE}, show output; if \code{FALSE}, hide output in
-R Markdown report. Default \code{NULL} does not change the "show" field
+R Markdown report. Default \code{NULL} does not change the "doc_show" field
 in \code{Evaluator}/\code{Visualizer}.}
+
+\item{nrows}{Maximum number of rows to show in the \code{Evaluator}'s results
+table in the R Markdown report. If \code{NULL}, shows all rows. Default does
+not change the "doc_nrows" field in the \code{Evaluator}. Argument is
+ignored if \code{field_name = "visualizer"}.}
 
 \item{...}{Named R Markdown options to set. If \code{field_name = "visualizer"},
 options are "height" and "width". If \code{field_name = "evaluator"},

--- a/man/set_rmd_options.Rd
+++ b/man/set_rmd_options.Rd
@@ -22,7 +22,7 @@ set_rmd_options(
 options.}
 
 \item{show}{If \code{TRUE}, show output; if \code{FALSE}, hide output in
-R Markdown report. Default \code{NULL} does not change the "show" field
+R Markdown report. Default \code{NULL} does not change the "doc_show" field
 in \code{Evaluator}/\code{Visualizer}.}
 
 \item{...}{Named R Markdown options to set. If \code{field_name = "visualizer"},

--- a/tests/testthat/test-docs.R
+++ b/tests/testthat/test-docs.R
@@ -243,6 +243,8 @@ withr::with_tempdir(pattern = "simChef-test-checkpointing-temp", code = {
       add_evaluator(evaluator4, "Evaluator (no show)") %>%
       set_doc_options(field_name = "evaluator", name = "Evaluator (digits = 4)",
                       digits = 4) %>%
+      set_doc_options(field_name = "evaluator", name = "Evaluator (digits = 4)",
+                      nrows = 10) %>%
       set_doc_options(field_name = "evaluator", name = "Evaluator (no show)",
                       show = FALSE) %>%
       add_visualizer(visualizer1, "Visualizer (height = 6)") %>%
@@ -267,6 +269,8 @@ withr::with_tempdir(pattern = "simChef-test-checkpointing-temp", code = {
     expect_equal(purrr::map_dbl(experiment$get_evaluators(),
                                 ~.x$doc_options$digits),
                  c(2, 3, 4, 2) %>% setNames(names(experiment$get_evaluators())))
+    expect_equal(purrr::map(experiment$get_evaluators(), "doc_nrows"),
+                 list(NULL, NULL, 10, NULL) %>% setNames(names(experiment$get_evaluators())))
     expect_equal(purrr::map_lgl(experiment$get_visualizers(), "doc_show"),
                  c(T, T, T, F) %>% setNames(names(experiment$get_visualizers())))
     expect_equal(purrr::map_dbl(experiment$get_visualizers(),

--- a/tests/testthat/test-evaluator.R
+++ b/tests/testthat/test-evaluator.R
@@ -14,7 +14,7 @@ test_that("Evaluator initialization works properly", {
                                                   caption = "caption"))
   evaluator1f <- Evaluator$new(.eval_fun = eval_fun1,
                                a = 5, b = 1:5, c = data.frame(d = 1:2))
-  evaluator1g <- Evaluator$new(.eval_fun = eval_fun1, .doc_show = FALSE)
+  evaluator1g <- Evaluator$new(.eval_fun = eval_fun1, .doc_show = FALSE, .doc_nrows = 10)
   evaluator1h <- Evaluator$new(eval_fun1, n = 100)
   evaluator1i <- Evaluator$new(n = 100, func = func, eval_fun1)
   evaluator1j <- Evaluator$new(eval_fun1, n = 100, "Evaluator")
@@ -38,6 +38,7 @@ test_that("Evaluator initialization works properly", {
                list(digits = 2, sigfig = FALSE,
                     options = list(scrollX = TRUE, scrollCollapse = TRUE)))
   expect_equal(evaluator1$doc_show, TRUE)
+  expect_equal(evaluator1$doc_nrows, NULL)
 
   # basic initialization with name
   expect_equal(evaluator1b$name, "Evaluator")
@@ -66,6 +67,7 @@ test_that("Evaluator initialization works properly", {
 
   # show doc input
   expect_equal(evaluator1g$doc_show, FALSE)
+  expect_equal(evaluator1g$doc_nrows, 10)
 
   # preventing eval_fun arg partial matching
   expect_equal(evaluator1h$eval_params, list(n = 100))
@@ -120,7 +122,7 @@ test_that("Evaluator initialization works properly", {
                                                      caption = "caption"))
   evaluator2f <- create_evaluator(.eval_fun = eval_fun1,
                                   a = 5, b = 1:5, c = data.frame(d = 1:2))
-  evaluator2g <- create_evaluator(.eval_fun = eval_fun1, .doc_show = FALSE)
+  evaluator2g <- create_evaluator(.eval_fun = eval_fun1, .doc_show = FALSE, .doc_nrows = 10)
   evaluator2h <- create_evaluator(eval_fun1, n = 100)
   evaluator2i <- create_evaluator(n = 100, func = func, eval_fun1)
   evaluator2j <- create_evaluator(eval_fun1, n = 100, "Evaluator")

--- a/vignettes/simChef-full.Rmd
+++ b/vignettes/simChef-full.Rmd
@@ -1057,6 +1057,7 @@ save_experiment(experiment)
 ```
 
 To hide the output of an `Evaluator` or `Visualizer` in the R Markdown report, use `set_doc_options(show = FALSE, ...)` or `create_*(.doc_show = FALSE, ...)`.
+Moreover, for an `Evaluator`, the maximum number of rows to display in the R Markdown report can be set via `set_doc_options(nrows = 10, ...)` or `create_*(.doc_nrows = 10, ...)`.
 Note that if document options are set after running the experiment, the experiment must be manually saved via `save_experiment(experiment)` in order for these changes to appear in the R Markdown output.
 
 ## Customizing aesthetics of R Markdown documentation


### PR DESCRIPTION
Allow option to set maximum number of rows to display for an `Evaluator` results table in the R Markdown report.

Can set this option in one of three ways:
* Manually set `doc_nrows` field in `Evaluator` object
* Set `.doc_nrows` in `Evaluator$new()` or `create_evaluator()`
* Set `nrows` argument in `set_doc_options()`

This follows the same api as the "show" option for `Evaluators`/`Visualizers`.

Closes #157 